### PR TITLE
PRS (scribe) for BLorient13309

### DIFF
--- a/new/PRS15043Fanta.xml
+++ b/new/PRS15043Fanta.xml
@@ -39,7 +39,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
         </profileDesc>
         <revisionDesc>
             <change who="CH" when="2025-09-25">Created record</change>
-            <!-- Add change note after review -->
+            <change when="2025-09-26" who="CH">Reviewed and approved by Magdalena Krzyżanowska</change>
         </revisionDesc>
     </teiHeader>
     <text>


### PR DESCRIPTION
I created record for PRS15043Fanta. He seems to have been active in or around Gondar in the 17th or 18th century. He is possibly the same as PRS14381Fanta, who is attested in Tegray. However, as long as I have no access to the manuscript images, I would not dare to establish an identification. I wanted to mention this possible identification in a relation, but I did not know which is the correct relation for it.