### PR TITLE
PRS (owners) of ANLcr67

### DIFF
--- a/new/PRS15476Laqac.xml
+++ b/new/PRS15476Laqac.xml
@@ -1,0 +1,64 @@
+<?xml-model href="https://raw.githubusercontent.com/BetaMasaheft/schema/master/tei-betamesaheft.rng" 
+schematypens="http://relaxng.org/ns/structure/1.0"?><?xml-model href="https://raw.githubusercontent.com/BetaMasaheft/schema/master/tei-betamesaheft.rng" 
+type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<TEI xmlns="http://www.tei-c.org/ns/1.0" xml:id="PRS15476Laqac" xml:lang="en" type="pers">
+    <teiHeader>
+        <fileDesc>
+            <titleStmt>
+                <title>Walatta Masqal Lāqač</title>
+                <editor role="generalEditor" key="AB"/>
+                <editor key="CH"/>
+                <funder>Akademie der Wissenschaften in Hamburg</funder>
+            </titleStmt>
+            <publicationStmt>
+                <authority>Hiob-Ludolf-Zentrum für Äthiopistik</authority>
+                <publisher>Die Schriftkultur des christlichen Äthiopiens und Eritreas: Eine multimediale
+                            Forschungsumgebung / Beta maṣāḥǝft</publisher>
+                <pubPlace>Hamburg</pubPlace>
+                <availability>
+                    <licence target="http://creativecommons.org/licenses/by-sa/4.0/"> This file is
+                                licensed under the Creative Commons Attribution-ShareAlike 4.0. </licence>
+                </availability>
+            </publicationStmt>
+            <sourceDesc>
+                <p/>
+            </sourceDesc>
+        </fileDesc>
+        <encodingDesc>
+            <p>A digital born TEI file</p>
+        </encodingDesc>
+        <profileDesc>
+            <creation/>
+            <abstract>
+                <p/>
+            </abstract>
+            <langUsage>
+                <language ident="en">English</language>
+                <language ident="gez">Gǝʿǝz</language>
+            </langUsage>
+        </profileDesc>
+        <revisionDesc>
+            <change who="CH" when="2026-06-29">Created record</change>
+            <!--  -->
+        </revisionDesc>
+    </teiHeader>
+    <text>
+        <body>
+            <listPerson>
+                <person sex="2">
+                    <persName xml:lang="gez" xml:id="n1">ወለተ፡ መስቀል፡ ላቀች፡</persName>
+                    <persName xml:lang="gez" type="normalized" corresp="#n1">Walatta Masqal Lāqač</persName>
+                    <floruit notBefore="1800" notAfter="1949">Nineteenth or first half of the twentieth century</floruit>
+                </person>
+                <listRelation>
+                    <relation name="saws:hasOwned" active="PRS15476Laqac" passive="ANLcr67"><desc>The name of the original owner was
+                        replaced various times with her name.</desc></relation>
+                    <!-- Possibly the same person as Lāqač, 'Queen of Goğğām' who owned EMDA321; Wayzaro Laqac who owned EMML504 or
+                       Wäyzäro Laqäč, who owned EMIP00138.While Lāqač is a common Ethiopian and Eritrean name, it is not certain, whether 
+                       these four mentions refer to the same persons even though all of them are are indicated as personalities either from the
+                       nineteenth or twentieth century.-->
+                </listRelation>
+            </listPerson>
+        </body>
+    </text>
+</TEI>

--- a/new/PRS15476Laqac.xml
+++ b/new/PRS15476Laqac.xml
@@ -5,7 +5,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
     <teiHeader>
         <fileDesc>
             <titleStmt>
-                <title>Walatta Masqal Lāqač</title>
+                <title>Walatta Masqal Lāqačč</title>
                 <editor role="generalEditor" key="AB"/>
                 <editor key="CH"/>
                 <funder>Akademie der Wissenschaften in Hamburg</funder>
@@ -39,7 +39,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
         </profileDesc>
         <revisionDesc>
             <change who="CH" when="2026-06-29">Created record</change>
-            <!--  -->
+            <change who="CH" when="2026-06-30">Updated after review of Magdalena Krzyżanowska</change>
         </revisionDesc>
     </teiHeader>
     <text>
@@ -47,16 +47,12 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
             <listPerson>
                 <person sex="2">
                     <persName xml:lang="gez" xml:id="n1">ወለተ፡ መስቀል፡ ላቀች፡</persName>
-                    <persName xml:lang="gez" type="normalized" corresp="#n1">Walatta Masqal Lāqač</persName>
+                    <persName xml:lang="gez" type="normalized" corresp="#n1">Walatta Masqal Lāqačč</persName>
                     <floruit notBefore="1800" notAfter="1949">Nineteenth or first half of the twentieth century</floruit>
                 </person>
                 <listRelation>
                     <relation name="saws:hasOwned" active="PRS15476Laqac" passive="ANLcr67"><desc>The name of the original owner was
-                        replaced various times with her name.</desc></relation>
-                    <!-- Possibly the same person as Lāqač, 'Queen of Goğğām' who owned EMDA321; Wayzaro Laqac who owned EMML504 or
-                       Wäyzäro Laqäč, who owned EMIP00138.While Lāqač is a common Ethiopian and Eritrean name, it is not certain, whether 
-                       these four mentions refer to the same persons even though all of them are are indicated as personalities either from the
-                       nineteenth or twentieth century.-->
+                        replaced in various places with her name.</desc></relation>
                 </listRelation>
             </listPerson>
         </body>

--- a/new/PRS15477WalattaKid.xml
+++ b/new/PRS15477WalattaKid.xml
@@ -39,19 +39,19 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
         </profileDesc>
         <revisionDesc>
             <change who="CH" when="2026-06-29">Created record</change>
-            <!--  -->
+            <change who="CH" when="2026-06-30">Updated after review of Magdalena Krzyżanowska</change>
         </revisionDesc>
     </teiHeader>
     <text>
         <body>
             <listPerson>
                 <person sex="2">
-                    <persName xml:lang="gez" xml:id="n1">ወለተ፡ ኪዳን፡</persName>
-                    <persName xml:lang="gez" type="normalized" corresp="#n1">Walatta Kidān </persName>
+                    <persName xml:lang="gez" xml:id="n1" type="baptismal">ወለተ፡ ኪዳን፡</persName>
+                    <persName xml:lang="gez" type="normalized" corresp="#n1">Walatta Kidān</persName>
                     <floruit notBefore="1800" notAfter="1899">Nineteenth century</floruit>
                 </person>
                 <listRelation>
-                    <relation name="saws:hasOwned" active="PRS15477WalattaKid" passive="ANLcr67"><desc>Named as original owner.</desc></relation>
+                    <relation name="saws:hasOwned" active="PRS15477WalattaKid" passive="ANLcr67"><desc>Named as the original owner.</desc></relation>
                 </listRelation>
             </listPerson>
         </body>

--- a/new/PRS15477WalattaKid.xml
+++ b/new/PRS15477WalattaKid.xml
@@ -1,0 +1,59 @@
+<?xml-model href="https://raw.githubusercontent.com/BetaMasaheft/schema/master/tei-betamesaheft.rng" 
+schematypens="http://relaxng.org/ns/structure/1.0"?><?xml-model href="https://raw.githubusercontent.com/BetaMasaheft/schema/master/tei-betamesaheft.rng" 
+type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<TEI xmlns="http://www.tei-c.org/ns/1.0" xml:id="PRS15477WalattaKid" xml:lang="en" type="pers">
+    <teiHeader>
+        <fileDesc>
+            <titleStmt>
+                <title>Walatta Kidān</title>
+                <editor role="generalEditor" key="AB"/>
+                <editor key="CH"/>
+                <funder>Akademie der Wissenschaften in Hamburg</funder>
+            </titleStmt>
+            <publicationStmt>
+                <authority>Hiob-Ludolf-Zentrum für Äthiopistik</authority>
+                <publisher>Die Schriftkultur des christlichen Äthiopiens und Eritreas: Eine multimediale
+                            Forschungsumgebung / Beta maṣāḥǝft</publisher>
+                <pubPlace>Hamburg</pubPlace>
+                <availability>
+                    <licence target="http://creativecommons.org/licenses/by-sa/4.0/"> This file is
+                                licensed under the Creative Commons Attribution-ShareAlike 4.0. </licence>
+                </availability>
+            </publicationStmt>
+            <sourceDesc>
+                <p/>
+            </sourceDesc>
+        </fileDesc>
+        <encodingDesc>
+            <p>A digital born TEI file</p>
+        </encodingDesc>
+        <profileDesc>
+            <creation/>
+            <abstract>
+                <p/>
+            </abstract>
+            <langUsage>
+                <language ident="en">English</language>
+                <language ident="gez">Gǝʿǝz</language>
+            </langUsage>
+        </profileDesc>
+        <revisionDesc>
+            <change who="CH" when="2026-06-29">Created record</change>
+            <!--  -->
+        </revisionDesc>
+    </teiHeader>
+    <text>
+        <body>
+            <listPerson>
+                <person sex="2">
+                    <persName xml:lang="gez" xml:id="n1">ወለተ፡ ኪዳን፡</persName>
+                    <persName xml:lang="gez" type="normalized" corresp="#n1">Walatta Kidān </persName>
+                    <floruit notBefore="1800" notAfter="1899">Nineteenth century</floruit>
+                </person>
+                <listRelation>
+                    <relation name="saws:hasOwned" active="PRS15477WalattaKid" passive="ANLcr67"><desc>Named as original owner.</desc></relation>
+                </listRelation>
+            </listPerson>
+        </body>
+    </text>
+</TEI>


### PR DESCRIPTION
I found three other manuscript records, which mention a female with the name Laqāč as owners, all of which date to the nineteenth or twentieth century. However, since Lāqač seems to be a common name in Ethiopia and Eritrea, I obstained from identifying the one with another.